### PR TITLE
Added mapped_hmget and mapped_hmset

### DIFF
--- a/lib/nest.rb
+++ b/lib/nest.rb
@@ -15,7 +15,7 @@ class Nest < String
   :ttl, :type, :unsubscribe, :watch, :zadd, :zcard, :zcount,
   :zincrby, :zinterstore, :zrange, :zrangebyscore, :zrank, :zrem,
   :zremrangebyrank, :zremrangebyscore, :zrevrange, :zrevrangebyscore,
-  :zrevrank, :zscore, :zunionstore]
+  :zrevrank, :zscore, :zunionstore, :mapped_hmget, :mapped_hmset]
 
   attr :redis
 


### PR DESCRIPTION
These `mapped` methods were not included, without good reason. (The other mapped methods cannot be included trivially as they map multiple keys.)